### PR TITLE
Fix KeyError and async cleanup issues

### DIFF
--- a/src/claude_code_sdk/_internal/client.py
+++ b/src/claude_code_sdk/_internal/client.py
@@ -86,13 +86,13 @@ class InternalClient:
                 # Map total_cost to total_cost_usd for consistency
                 return ResultMessage(
                     subtype=data["subtype"],
-                    cost_usd=data["cost_usd"],
+                    cost_usd=data.get("cost_usd", data.get("total_cost", 0.0)),
                     duration_ms=data["duration_ms"],
                     duration_api_ms=data["duration_api_ms"],
                     is_error=data["is_error"],
                     num_turns=data["num_turns"],
                     session_id=data["session_id"],
-                    total_cost_usd=data["total_cost"],
+                    total_cost_usd=data.get("total_cost", 0.0),
                     usage=data.get("usage"),
                     result=data.get("result"),
                 )


### PR DESCRIPTION
## Summary
- Fix KeyError for 'cost_usd' field by using `.get()` with fallback to 'total_cost'
- Handle GeneratorExit exception during async cleanup to prevent unhandled exceptions
- Add try/except for `cancel_scope.cancel()` to prevent RuntimeError when cancel scope is already exited

## Problem
When using the claude-code-sdk with Claude Code CLI, users encounter:
1. `KeyError: 'cost_usd'` when parsing result messages
2. Unhandled exceptions during asyncio shutdown related to task cancellation

## Solution
1. Use `.get()` method with fallback values for optional fields
2. Properly handle cleanup exceptions in the async context manager

## Test plan
- [x] Tested with example scripts that previously failed
- [x] Verified SDK works without runtime errors
- [x] Both simple queries and multi-turn conversations work correctly