### PR TITLE
Fix: Handle Incomplete and Malformed JSON in Subprocess Stream Parser

### DIFF
--- a/src/claude_code_sdk/_internal/transport/subprocess_cli.py
+++ b/src/claude_code_sdk/_internal/transport/subprocess_cli.py
@@ -198,6 +198,7 @@ class SubprocessCLITransport(Transport):
                         logger.warning("JSON buffer exceeded 1MB limit. Discarding buffered data: %s", json_buffer[:200])
                         json_buffer = ""
                         continue
+
                     try:
                         data = json.loads(json_buffer)
                         yield data
@@ -209,7 +210,7 @@ class SubprocessCLITransport(Transport):
                         open_brackets = json_buffer.count("[") - json_buffer.count("]")
 
                         if open_braces == 0 and open_brackets == 0:
-                                 logger.warning("Malformed JSON detected: %s", json_buffer[:200])
+                            logger.warning("Malformed JSON detected: %s", json_buffer[:200])
                             raise SDKJSONDecodeError(json_buffer, e) from e
 
                         logger.debug(

--- a/src/claude_code_sdk/_internal/transport/subprocess_cli.py
+++ b/src/claude_code_sdk/_internal/transport/subprocess_cli.py
@@ -190,6 +190,11 @@ class SubprocessCLITransport(Transport):
                         continue
 
                     json_buffer += line_str
+                    try:
+                        data = json.loads(json_buffer)
+                        yield data
+                        json_buffer = ""
+
                     except json.JSONDecodeError as e:
                     if json_buffer.startswith("{") or json_buffer.startswith("["):
                         open_braces = json_buffer.count("{") - json_buffer.count("}")

--- a/src/claude_code_sdk/_internal/transport/subprocess_cli.py
+++ b/src/claude_code_sdk/_internal/transport/subprocess_cli.py
@@ -169,7 +169,7 @@ class SubprocessCLITransport(Transport):
             raise CLIConnectionError("Not connected")
 
         stderr_lines = []
-        json_buffer= ""
+        json_buffer = ""
 
         async def read_stderr() -> None:
             """Read stderr in background."""


### PR DESCRIPTION
This pull request fixes a recurring issue where the SDK throws `CLIJSONDecodeError` due to incomplete or concatenated JSON objects in the subprocess output stream. The CLI occasionally emits partial or multiple JSON chunks across lines, which previously caused the parser to fail with `json.decoder.JSONDecodeError: Extra data`.