### PR TITLE
Find claude when installed by /migrate-installer

### DIFF
--- a/src/claude_code_sdk/_internal/transport/subprocess_cli.py
+++ b/src/claude_code_sdk/_internal/transport/subprocess_cli.py
@@ -44,6 +44,7 @@ class SubprocessCLITransport(Transport):
             Path.home() / ".npm-global/bin/claude",
             Path("/usr/local/bin/claude"),
             Path.home() / ".local/bin/claude",
+            Path.home() / ".claude/local/claude",
             Path.home() / "node_modules/.bin/claude",
             Path.home() / ".yarn/bin/claude",
         ]


### PR DESCRIPTION
In `claude`, the `/migrate-installer` command removes the global claude and installs the executable under `~/.claude/local/claude`. (This executable is only a wrapper but it does not matter)