### PR TITLE
Explicit error if the cwd does not exist

### DIFF
--- a/src/claude_code_sdk/_internal/transport/subprocess_cli.py
+++ b/src/claude_code_sdk/_internal/transport/subprocess_cli.py
@@ -136,6 +136,11 @@ class SubprocessCLITransport(Transport):
                 self._stderr_stream = TextReceiveStream(self._process.stderr)
 
         except FileNotFoundError as e:
+            # Check if the error comes from the working directory or the CLI
+            if self._cwd and not Path(self._cwd).exists():
+                raise CLIConnectionError(
+                    f"Working directory does not exist: {self._cwd}"
+                ) from e
             raise CLINotFoundError(f"Claude Code not found at: {self._cli_path}") from e
         except Exception as e:
             raise CLIConnectionError(f"Failed to start Claude Code: {e}") from e

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -132,3 +132,21 @@ class TestSubprocessCLITransport:
         # So we just verify the transport can be created and basic structure is correct
         assert transport._prompt == "test"
         assert transport._cli_path == "/usr/bin/claude"
+
+    def test_connect_with_nonexistent_cwd(self):
+        """Test that connect raises CLIConnectionError when cwd doesn't exist."""
+        from claude_code_sdk._errors import CLIConnectionError
+
+        async def _test():
+            transport = SubprocessCLITransport(
+                prompt="test",
+                options=ClaudeCodeOptions(cwd="/this/directory/does/not/exist"),
+                cli_path="/usr/bin/claude",
+            )
+
+            with pytest.raises(CLIConnectionError) as exc_info:
+                await transport.connect()
+
+            assert "/this/directory/does/not/exist" in str(exc_info.value)
+
+        anyio.run(_test)


### PR DESCRIPTION
Previously was raised as a `CLINotFoundError` because it's also caught by the `FileNotFoundError` exception handler.