### PR TITLE
feat: automate version updates after PyPI release

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -1,0 +1,59 @@
+name: Create Release Tag
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  create-tag:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    
+    - name: Extract version from branch name
+      id: extract_version
+      run: |
+        BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+        VERSION="${BRANCH_NAME#release/v}"
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+    
+    - name: Create and push tag
+      run: |
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        
+        # Create annotated tag
+        git tag -a "v${{ steps.extract_version.outputs.version }}" \
+          -m "Release v${{ steps.extract_version.outputs.version }}"
+        
+        # Push tag
+        git push origin "v${{ steps.extract_version.outputs.version }}"
+    
+    - name: Create GitHub Release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v${{ steps.extract_version.outputs.version }}
+        release_name: Release v${{ steps.extract_version.outputs.version }}
+        body: |
+          ## Release v${{ steps.extract_version.outputs.version }}
+          
+          Published to PyPI: https://pypi.org/project/claude-code-sdk/${{ steps.extract_version.outputs.version }}/
+          
+          ### Installation
+          ```bash
+          pip install claude-code-sdk==${{ steps.extract_version.outputs.version }}
+          ```
+          
+          ### What's Changed
+          See the [full changelog](https://github.com/${{ github.repository }}/compare/v${{ steps.extract_version.outputs.version }}...v${{ steps.extract_version.outputs.version }})
+        draft: false
+        prerelease: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,9 +65,14 @@ jobs:
   publish:
     needs: [test, lint]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     
     steps:
     - uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
     
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -109,3 +114,40 @@ jobs:
         twine upload dist/*
         echo "Package published to PyPI"
         echo "Install with: pip install claude-code-sdk==${{ github.event.inputs.version }}"
+    
+    - name: Create version update PR
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Create a new branch for the version update
+        BRANCH_NAME="release/v${{ github.event.inputs.version }}"
+        git checkout -b "$BRANCH_NAME"
+        
+        # Configure git
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        
+        # Commit the version changes
+        git add pyproject.toml src/claude_code_sdk/__init__.py
+        git commit -m "chore: bump version to ${{ github.event.inputs.version }}"
+        
+        # Push the branch
+        git push origin "$BRANCH_NAME"
+        
+        # Create PR using GitHub CLI (gh)
+        gh pr create \
+          --title "chore: bump version to ${{ github.event.inputs.version }}" \
+          --body "This PR updates the version to ${{ github.event.inputs.version }} after publishing to PyPI.
+          
+          ## Changes
+          - Updated version in \`pyproject.toml\`
+          - Updated version in \`src/claude_code_sdk/__init__.py\`
+          
+          ## Release Information
+          - Published to PyPI: https://pypi.org/project/claude-code-sdk/${{ github.event.inputs.version }}/
+          - Install with: \`pip install claude-code-sdk==${{ github.event.inputs.version }}\`
+          
+          ## Next Steps
+          After merging this PR, a release tag will be created automatically." \
+          --base main \
+          --head "$BRANCH_NAME"


### PR DESCRIPTION
## Summary

This PR updates the release workflow to automatically create a PR with version updates after publishing to PyPI, eliminating the need for manual version syncing.

## Problem
Currently, after publishing a new version to PyPI, the version in the repository (pyproject.toml) remains outdated. This has led to a version mismatch where:
- Repository shows: v0.0.10
- PyPI shows: v0.0.12

## Solution
1. **Updated **: After successfully publishing to PyPI, the workflow now:
   - Creates a new branch
   - Commits the version updates
   - Opens a PR automatically

2. **Added **: When a release PR is merged, this workflow:
   - Creates a git tag for the version
   - Creates a GitHub release

## Benefits
- ✅ No more manual version updates
- ✅ Repository version always matches PyPI
- ✅ Automatic release tagging
- ✅ Clear audit trail via PRs

## Note
PRs created by the workflow won't automatically trigger CI due to GitHub's security model. To run CI on the version update PR, you can:
- Push an empty commit to the branch
- Close and reopen the PR
- Or merge directly if you trust the release process

## Testing
The next release will use this automated process. The workflow will:
1. Publish to PyPI as usual
2. Create a PR titled "chore: bump version to X.X.X"
3. After merging, create a release tag automatically