### PR TITLE
chore: bump version to 0.0.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-code-sdk"
-version = "0.0.10"
+version = "0.0.13"
 description = "Python SDK for Claude Code"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/claude_code_sdk/__init__.py
+++ b/src/claude_code_sdk/__init__.py
@@ -26,7 +26,7 @@ from .types import (
     UserMessage,
 )
 
-__version__ = "0.0.10"
+__version__ = "0.0.13"
 
 __all__ = [
     # Main function


### PR DESCRIPTION
This PR updates the version to 0.0.13 after publishing to PyPI.

## Changes
- Updated version in `pyproject.toml`
- Updated version in `src/claude_code_sdk/__init__.py`

## Release Information
- ✅ Published to PyPI: https://pypi.org/project/claude-code-sdk/0.0.13/
- 📦 Install with: `pip install claude-code-sdk==0.0.13`

## Notes
- This is a clean PR with verified commits only
- Previous PR #47 was closed due to unverified commit from GitHub Actions bot
- CI checks should run automatically on this PR

## Next Steps
After merging this PR, a release tag will be created automatically via the `create-release-tag.yml` workflow.