### PR TITLE
fix: changelog comparison URL in release workflow

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -29,6 +29,7 @@ jobs:
       run: |
         PREVIOUS_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || echo "")
         echo "previous_tag=$PREVIOUS_TAG" >> $GITHUB_OUTPUT
+
     - name: Create and push tag
       run: |
         git config --local user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -24,6 +24,11 @@ jobs:
         VERSION="${BRANCH_NAME#release/v}"
         echo "version=$VERSION" >> $GITHUB_OUTPUT
     
+    - name: Get previous release tag
+      id: previous_tag
+      run: |
+        PREVIOUS_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || echo "")
+        echo "previous_tag=$PREVIOUS_TAG" >> $GITHUB_OUTPUT
     - name: Create and push tag
       run: |
         git config --local user.email "github-actions[bot]@users.noreply.github.com"
@@ -54,6 +59,6 @@ jobs:
           ```
           
           ### What's Changed
-          See the [full changelog](https://github.com/${{ github.repository }}/compare/v${{ steps.extract_version.outputs.version }}...v${{ steps.extract_version.outputs.version }})
+          See the [full changelog](https://github.com/${{ github.repository }}/compare/${{ steps.previous_tag.outputs.previous_tag }}...v${{ steps.extract_version.outputs.version }})
         draft: false
         prerelease: false


### PR DESCRIPTION
## Summary
- Fix changelog comparison URL that was comparing the same version against itself
- Now correctly compares against the previous release tag to show actual changes

## Problem
The release workflow was generating changelog URLs like `v1.0.0...v1.0.0` which shows no changes, instead of comparing against the previous release.

## Solution
```yaml
# Before
compare/v${{ steps.extract_version.outputs.version }}...v${{ steps.extract_version.outputs.version }}

# After  
compare/${{ steps.previous_tag.outputs.previous_tag }}...v${{ steps.extract_version.outputs.version }}
```

Added a step to get the previous release tag using `git describe --tags --abbrev=0 HEAD~1`.

## Test plan
- [ ] Verify workflow runs without errors
- [ ] Check that changelog URLs in releases now show actual changes between versions