### PR TITLE
Fix: Decode single message over multiple stream reads

### DIFF
--- a/src/claude_code_sdk/_internal/transport/subprocess_cli.py
+++ b/src/claude_code_sdk/_internal/transport/subprocess_cli.py
@@ -18,6 +18,8 @@ from ...types import ClaudeCodeOptions
 from . import Transport
 
 
+_MAX_BUFFER_SIZE = 1 * 1024 * 1024 # 1MB
+
 class SubprocessCLITransport(Transport):
     """Subprocess transport using Claude Code CLI."""
 
@@ -197,9 +199,13 @@ class SubprocessCLITransport(Transport):
                         json_line = json_line.strip()
                         if not json_line:
                             continue
-
+                        
+                        json_buffer += json_line
+                        if(len(json_buffer.encode(self._stdout_stream.encoding)) > _MAX_BUFFER_SIZE):
+                            raise OverflowError(f"JSON message buffer exceeded max size: "
+                                                f"{_MAX_BUFFER_SIZE/(1024*1024)} MB")
+                        
                         try:
-                            json_buffer += json_line
                             data = json.loads(json_buffer)
                             json_buffer = ""
                             try:

--- a/tests/test_subprocess_buffering.py
+++ b/tests/test_subprocess_buffering.py
@@ -17,6 +17,7 @@ class MockTextReceiveStream:
     def __init__(self, lines: list[str]) -> None:
         self.lines = lines
         self.index = 0
+        self.encoding = "utf-8"
 
     def __aiter__(self) -> AsyncIterator[str]:
         return self
@@ -140,7 +141,7 @@ class TestSubprocessBuffering:
 
         anyio.run(_test)
         
-    def test_object_over_buffer_limit(self) -> None:
+    def test_objects_over_buffer_limit(self) -> None:
         """Test parsing with a json object larger than the buffer limit."""
 
         async def _test() -> None:


### PR DESCRIPTION
This PR aims to fix the issue claude code exiting due to parsing failure of a single json message over multiple stream reads.
The default maximum size of asyncio stream is 64KB. This limit can easily be breached when claude code invokes a tool to read a file of over 1000 lines.
Since a single message split over multiple stream reads, attempting to decode it as json leads to JSONDecodeError.

This PR includes a test case in test_subprocess_buffer to demonstrate the issue.
The test case fails without the fix.

To fix the issue, a buffer (accumulator variable) is initialised as an empty string. If there is a JSONDecodeError, the stream read is appended to the buffer. This cumulative buffer will be parsed. This will continue until the buffer has the complete JSON and is parsed successfully.

To avoid, the buffer increasing infinitely, an arbitrary limit of 1MB (for now) has been put on the buffer, post which it'll result in an OverflowError.