### PR TITLE
fix: handle JSON messages split across multiple stream reads

### DIFF
--- a/src/claude_code_sdk/_internal/transport/subprocess_cli.py
+++ b/src/claude_code_sdk/_internal/transport/subprocess_cli.py
@@ -17,6 +17,8 @@ from ..._errors import CLIJSONDecodeError as SDKJSONDecodeError
 from ...types import ClaudeCodeOptions
 from . import Transport
 
+_MAX_BUFFER_SIZE = 1024 * 1024  # 1MB buffer limit
+
 
 class SubprocessCLITransport(Transport):
     """Subprocess transport using Claude Code CLI."""
@@ -182,6 +184,9 @@ class SubprocessCLITransport(Transport):
         async with anyio.create_task_group() as tg:
             tg.start_soon(read_stderr)
 
+            # Buffer for incomplete JSON
+            json_buffer = ""
+
             try:
                 async for line in self._stdout_stream:
                     line_str = line.strip()
@@ -196,16 +201,27 @@ class SubprocessCLITransport(Transport):
                         if not json_line:
                             continue
 
+                        # Add to buffer
+                        json_buffer += json_line
+
+                        # Check buffer size
+                        if len(json_buffer) > _MAX_BUFFER_SIZE:
+                            json_buffer = ""  # Clear buffer to prevent repeated errors
+                            raise SDKJSONDecodeError(
+                                f"JSON message exceeded maximum buffer size of {_MAX_BUFFER_SIZE} bytes",
+                                None
+                            )
+
                         try:
-                            data = json.loads(json_line)
+                            data = json.loads(json_buffer)
+                            json_buffer = ""  # Clear buffer on successful parse
                             try:
                                 yield data
                             except GeneratorExit:
                                 # Handle generator cleanup gracefully
                                 return
-                        except json.JSONDecodeError as e:
-                            if json_line.startswith("{") or json_line.startswith("["):
-                                raise SDKJSONDecodeError(json_line, e) from e
+                        except json.JSONDecodeError:
+                            # Continue accumulating in buffer
                             continue
 
             except anyio.ClosedResourceError:


### PR DESCRIPTION
## Summary
Fixes CLIJSONDecodeError when Claude Code CLI returns large JSON messages that exceed asyncio's default 64KB stream buffer limit.

## Problem
When JSON messages are larger than the stream buffer, they arrive split across multiple reads. The previous implementation attempted to parse each fragment immediately, resulting in JSONDecodeError.

## Solution
- Add buffering to accumulate incomplete JSON messages
- Continue accumulating until a complete JSON object can be parsed
- Implement 1MB maximum buffer size to prevent unbounded growth
- Clear buffer after successful parse or when limit exceeded

## Testing
Added comprehensive test coverage:
- Split JSON across multiple reads
- Large minified JSON (simulating reported issue)
- Buffer size limit enforcement
- Mixed complete and partial messages

🤖 Generated with [Claude Code](https://claude.ai/code)