### PR TITLE
Fix bypassPermissions silent failure (Issue #30)

### DIFF
--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -132,3 +132,179 @@ class TestSubprocessCLITransport:
         # So we just verify the transport can be created and basic structure is correct
         assert transport._prompt == "test"
         assert transport._cli_path == "/usr/bin/claude"
+
+    def test_bypass_permissions_disabled_error(self):
+        """Test that bypassPermissions being disabled raises proper error."""
+        from claude_code_sdk._errors import ProcessError
+        from anyio.streams.text import TextReceiveStream
+        from anyio import ClosedResourceError
+
+        async def _test():
+            with patch("anyio.open_process") as mock_exec:
+                # Create a mock process that simulates the CLI behavior
+                mock_process = MagicMock()
+                mock_process.returncode = 0  # CLI exits successfully
+                mock_process.wait = AsyncMock()
+                
+                # Create mock stdout/stderr streams
+                mock_stdout_stream = AsyncMock()
+                mock_stderr_stream = AsyncMock()
+                
+                # Simulate empty stdout (no JSON messages) followed by closed stream
+                async def stdout_iter(self):
+                    raise ClosedResourceError()
+                    yield  # This won't be reached
+                
+                # Simulate stderr with the warning message
+                async def stderr_iter(self):
+                    yield "[ERROR] bypassPermissions mode is disabled by settings"
+                    raise ClosedResourceError()
+                
+                type(mock_stdout_stream).__aiter__ = stdout_iter
+                type(mock_stderr_stream).__aiter__ = stderr_iter
+                
+                mock_process.stdout = MagicMock()
+                mock_process.stderr = MagicMock()
+                mock_exec.return_value = mock_process
+
+                # Patch TextReceiveStream to return our mocks
+                with patch("claude_code_sdk._internal.transport.subprocess_cli.TextReceiveStream") as mock_text_stream:
+                    mock_text_stream.side_effect = [mock_stdout_stream, mock_stderr_stream]
+                    
+                    transport = SubprocessCLITransport(
+                        prompt="test",
+                        options=ClaudeCodeOptions(permission_mode="bypassPermissions"),
+                        cli_path="/usr/bin/claude",
+                    )
+
+                    await transport.connect()
+                    
+                    with pytest.raises(ProcessError) as exc_info:
+                        # Consume all messages to trigger the error check
+                        async for _ in transport.receive_messages():
+                            pass
+                    
+                    assert "bypassPermissions mode is disabled" in str(exc_info.value)
+                    assert "requires user input" in str(exc_info.value)
+                    assert "acceptEdits" in str(exc_info.value)
+
+        anyio.run(_test)
+
+    def test_bypass_permissions_adds_debug_flag(self):
+        """Test that bypassPermissions mode adds --debug flag to command."""
+        transport = SubprocessCLITransport(
+            prompt="test",
+            options=ClaudeCodeOptions(permission_mode="bypassPermissions"),
+            cli_path="/usr/bin/claude",
+        )
+
+        cmd = transport._build_command()
+        assert "--debug" in cmd
+
+    def test_bypass_permissions_root_user_error(self):
+        """Test that running as root with bypassPermissions raises proper error."""
+        from claude_code_sdk._errors import ProcessError
+        from anyio import ClosedResourceError
+
+        async def _test():
+            with patch("anyio.open_process") as mock_exec:
+                # Create a mock process that exits with code 1 (root user rejection)
+                mock_process = MagicMock()
+                mock_process.returncode = 1
+                mock_process.wait = AsyncMock()
+                
+                # Create mock stdout/stderr streams
+                mock_stdout_stream = AsyncMock()
+                mock_stderr_stream = AsyncMock()
+                
+                # Simulate empty stdout
+                async def stdout_iter(self):
+                    raise ClosedResourceError()
+                    yield  # Won't be reached
+                
+                # Simulate stderr with root user error
+                async def stderr_iter(self):
+                    yield "--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons"
+                    raise ClosedResourceError()
+                
+                type(mock_stdout_stream).__aiter__ = stdout_iter
+                type(mock_stderr_stream).__aiter__ = stderr_iter
+                
+                mock_process.stdout = MagicMock()
+                mock_process.stderr = MagicMock()
+                mock_exec.return_value = mock_process
+
+                # Patch TextReceiveStream to return our mocks
+                with patch("claude_code_sdk._internal.transport.subprocess_cli.TextReceiveStream") as mock_text_stream:
+                    mock_text_stream.side_effect = [mock_stdout_stream, mock_stderr_stream]
+                    
+                    transport = SubprocessCLITransport(
+                        prompt="test",
+                        options=ClaudeCodeOptions(permission_mode="bypassPermissions"),
+                        cli_path="/usr/bin/claude",
+                    )
+
+                    await transport.connect()
+                    
+                    with pytest.raises(ProcessError) as exc_info:
+                        async for _ in transport.receive_messages():
+                            pass
+                    
+                    assert "cannot be used when running as root/sudo" in str(exc_info.value)
+                    assert "Run as a non-root user" in str(exc_info.value)
+
+        anyio.run(_test)
+
+    def test_bypass_permissions_no_output(self):
+        """Test bypassPermissions mode that exits without any output."""
+        from claude_code_sdk._errors import ProcessError
+        from anyio import ClosedResourceError
+
+        async def _test():
+            with patch("anyio.open_process") as mock_exec:
+                # Create a mock process that exits cleanly but produces no output
+                mock_process = MagicMock()
+                mock_process.returncode = 0  # Clean exit
+                mock_process.wait = AsyncMock()
+                
+                # Create mock stdout/stderr streams that immediately close
+                mock_stdout_stream = AsyncMock()
+                mock_stderr_stream = AsyncMock()
+                
+                # Both streams immediately close without yielding anything
+                async def empty_iter(self):
+                    raise ClosedResourceError()
+                    yield  # Won't be reached
+                
+                type(mock_stdout_stream).__aiter__ = empty_iter
+                type(mock_stderr_stream).__aiter__ = empty_iter
+                
+                mock_process.stdout = MagicMock()
+                mock_process.stderr = MagicMock()
+                mock_exec.return_value = mock_process
+
+                # Patch TextReceiveStream to return our mocks
+                with patch("claude_code_sdk._internal.transport.subprocess_cli.TextReceiveStream") as mock_text_stream:
+                    mock_text_stream.side_effect = [mock_stdout_stream, mock_stderr_stream]
+                    
+                    transport = SubprocessCLITransport(
+                        prompt="test",
+                        options=ClaudeCodeOptions(permission_mode="bypassPermissions"),
+                        cli_path="/usr/bin/claude",
+                    )
+
+                    await transport.connect()
+                    
+                    with pytest.raises(ProcessError) as exc_info:
+                        # This simulates the "no response" issue - the iterator completes
+                        # without yielding any messages
+                        async for _ in transport.receive_messages():
+                            pass
+                    
+                    error_msg = str(exc_info.value)
+                    assert "terminated without producing any output" in error_msg
+                    assert "bypassPermissions mode" in error_msg
+                    assert "Running as root/sudo" in error_msg
+                    assert "acceptEdits" in error_msg
+
+        anyio.run(_test)


### PR DESCRIPTION
## Summary

Fixes #30 - When `permission_mode='bypassPermissions'` fails, users experience a silent failure where their async iterator completes without yielding any messages.

## Problem

Users report "no response is received and the program terminates" when using `bypassPermissions`. The async for loop completes without executing its body, making it appear as if nothing happened.

## Root Causes

1. **CLI version incompatibility** - Older CLIs don't recognize `--permission-mode` flag
2. **Root user restriction** - Security check prevents bypassPermissions when running as root
3. **Disabled in settings** - Falls back to interactive mode when disabled
4. **Other security restrictions** - Various scenarios causing the CLI to exit without output

## Solution

This PR adds comprehensive error detection that transforms silent failures into clear, actionable error messages:

- Tracks whether ANY output was received (`_received_any_output`)
- Checks stderr for specific error patterns
- Provides different error messages for different failure modes
- Adds `--debug` flag for bypassPermissions to capture more diagnostics
- Updates entrypoint to 'sdk-cli' for better CLI integration

## Changes

- **subprocess_cli.py**: Enhanced error detection and reporting
- **test_transport.py**: Added comprehensive tests for all failure scenarios

## Test Plan

- [x] Added unit tests for all error scenarios
- [x] Manually tested with old CLI version
- [x] Verified error messages are clear and actionable
- [x] All existing tests pass

## Example

Before (silent failure):
```python
async for message in query(prompt="test", options=ClaudeCodeOptions(permission_mode="bypassPermissions")):
    print("Got message\!")  # This never executes, confusing users
```

After (clear error):
```
ProcessError: Claude Code CLI terminated without producing any output when using bypassPermissions mode. This can happen when:
1. Running as root/sudo (security restriction)
2. bypassPermissions is disabled in settings
3. Other security restrictions are in place

Try using permission_mode='acceptEdits' instead, which is the recommended mode for SDK usage.
```

🤖 Generated with [Claude Code](https://claude.ai/code)