### PR TITLE
chore: bump version to 0.0.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-code-sdk"
-version = "0.0.13"
+version = "0.0.14"
 description = "Python SDK for Claude Code"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/claude_code_sdk/__init__.py
+++ b/src/claude_code_sdk/__init__.py
@@ -26,7 +26,7 @@ from .types import (
     UserMessage,
 )
 
-__version__ = "0.0.13"
+__version__ = "0.0.14"
 
 __all__ = [
     # Main function


### PR DESCRIPTION
This PR updates the version to 0.0.14 after publishing to PyPI.

## Changes
- Updated version in `pyproject.toml`
- Updated version in `src/claude_code_sdk/__init__.py`

## Release Information
- Published to PyPI: https://pypi.org/project/claude-code-sdk/0.0.14/
- Install with: `pip install claude-code-sdk==0.0.14`

## Next Steps
After merging this PR, a release tag will be created automatically.

Note: This PR includes commit signing as requested.