### PR TITLE
feat: add strict_mcp_config option to Python SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,32 @@ options = ClaudeCodeOptions(
 )
 ```
 
+### MCP Servers
+
+```python
+# Configure MCP servers programmatically
+options = ClaudeCodeOptions(
+    mcp_servers={
+        "memory-server": {
+            "command": "npx",
+            "args": ["@modelcontextprotocol/server-memory"]
+        }
+    }
+)
+
+# Use strict MCP config to ignore all file-based configurations
+# This ensures ONLY your programmatically specified servers are used
+options = ClaudeCodeOptions(
+    mcp_servers={
+        "my-server": {
+            "command": "node",
+            "args": ["my-mcp-server.js"]
+        }
+    },
+    strict_mcp_config=True  # Ignore global/project MCP settings
+)
+```
+
 ## API Reference
 
 ### `query(prompt, options=None)`

--- a/examples/strict_mcp_config_example.py
+++ b/examples/strict_mcp_config_example.py
@@ -1,0 +1,41 @@
+"""Example demonstrating how to use strict MCP config with Claude SDK.
+
+This example shows how to use the strict_mcp_config option to ensure
+only your programmatically specified MCP servers are used, ignoring
+any global or project-level MCP configurations.
+"""
+
+from claude_code_sdk import ClaudeCodeSDK, ClaudeCodeOptions
+
+async def main():
+    # Create options with strict MCP config enabled
+    # This ensures ONLY the MCP servers specified here will be used
+    options = ClaudeCodeOptions(
+        mcp_servers={
+            "my-custom-server": {
+                "command": "npx",
+                "args": ["@modelcontextprotocol/server-memory"],
+            }
+        },
+        strict_mcp_config=True,  # Ignore all file-based MCP configurations
+    )
+    
+    # Create SDK instance
+    sdk = ClaudeCodeSDK()
+    
+    # Query Claude with strict MCP config
+    async with await sdk.query(
+        "List the available MCP tools from the memory server", 
+        options=options
+    ) as session:
+        async for message in session.stream():
+            if message.type == "assistant":
+                print(f"Claude: {message.message.content}")
+            elif message.type == "result":
+                print(f"\nResult: {message.subtype}")
+                if message.result:
+                    print(f"Final output: {message.result}")
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(main())

--- a/src/claude_code_sdk/_internal/transport/subprocess_cli.py
+++ b/src/claude_code_sdk/_internal/transport/subprocess_cli.py
@@ -116,6 +116,9 @@ class SubprocessCLITransport(Transport):
                 ["--mcp-config", json.dumps({"mcpServers": self._options.mcp_servers})]
             )
 
+        if self._options.strict_mcp_config:
+            cmd.append("--strict-mcp-config")
+
         cmd.extend(["--print", self._prompt])
         return cmd
 

--- a/src/claude_code_sdk/types.py
+++ b/src/claude_code_sdk/types.py
@@ -127,3 +127,4 @@ class ClaudeCodeOptions:
     model: str | None = None
     permission_prompt_tool_name: str | None = None
     cwd: str | Path | None = None
+    strict_mcp_config: bool = False

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -132,3 +132,24 @@ class TestSubprocessCLITransport:
         # So we just verify the transport can be created and basic structure is correct
         assert transport._prompt == "test"
         assert transport._cli_path == "/usr/bin/claude"
+
+    def test_build_command_with_strict_mcp_config(self):
+        """Test building CLI command with strict MCP config."""
+        transport = SubprocessCLITransport(
+            prompt="test",
+            options=ClaudeCodeOptions(strict_mcp_config=True),
+            cli_path="/usr/bin/claude",
+        )
+
+        cmd = transport._build_command()
+        assert "--strict-mcp-config" in cmd
+        
+        # Test that flag is not present when False
+        transport_no_strict = SubprocessCLITransport(
+            prompt="test",
+            options=ClaudeCodeOptions(strict_mcp_config=False),
+            cli_path="/usr/bin/claude",
+        )
+        
+        cmd_no_strict = transport_no_strict._build_command()
+        assert "--strict-mcp-config" not in cmd_no_strict

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -105,3 +105,12 @@ class TestOptions:
         )
         assert options.model == "claude-3-5-sonnet-20241022"
         assert options.permission_prompt_tool_name == "CustomTool"
+
+    def test_claude_code_options_with_strict_mcp_config(self):
+        """Test Options with strict MCP config."""
+        options = ClaudeCodeOptions(strict_mcp_config=True)
+        assert options.strict_mcp_config is True
+        
+        # Test default value
+        default_options = ClaudeCodeOptions()
+        assert default_options.strict_mcp_config is False


### PR DESCRIPTION
## Summary
- Add `strict_mcp_config` option to Python SDK to enable users to ignore all file-based MCP configurations
- This is a follow-up to anthropics/claude-cli-internal#4392 which added the `--strict-mcp-config` CLI flag

## Changes
- Add `strict_mcp_config: bool = False` field to `ClaudeCodeOptions` dataclass
- Update `SubprocessCLITransport` to pass `--strict-mcp-config` flag when option is True
- Add tests for the new option in both types and transport tests
- Add example demonstrating usage (`examples/strict_mcp_config_example.py`)
- Update README with MCP server configuration documentation

## Testing
- Added unit tests for the new field in `test_types.py`
- Added transport tests to verify CLI flag is passed correctly
- All existing tests pass

## Example Usage
```python
from claude_code_sdk import ClaudeCodeSDK, ClaudeCodeOptions

# Use strict MCP config to ensure ONLY specified servers are used
options = ClaudeCodeOptions(
    mcp_servers={
        "my-server": {
            "command": "node",
            "args": ["my-mcp-server.js"]
        }
    },
    strict_mcp_config=True  # Ignore all file-based MCP configurations
)
```

## Related
- CLI implementation: anthropics/claude-cli-internal#4392
- Original issue: anthropics/claude-cli-internal#45

🤖 Generated with [Claude Code](https://claude.ai/code)