### PR TITLE
Fix typing_extensions import to avoid ModuleNotFoundError on Python 3.11+

### DIFF
--- a/src/claude_code_sdk/types.py
+++ b/src/claude_code_sdk/types.py
@@ -1,10 +1,14 @@
 """Type definitions for Claude SDK."""
 
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal, TypedDict
 
-from typing_extensions import NotRequired  # For Python < 3.11 compatibility
+if sys.version_info >= (3, 11):
+    from typing import NotRequired
+else:
+    from typing_extensions import NotRequired
 
 # Permission modes
 PermissionMode = Literal["default", "acceptEdits", "bypassPermissions"]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,8 @@
 """Tests for Claude SDK type definitions."""
 
+import sys
+import importlib
+import pytest
 from claude_code_sdk import (
     AssistantMessage,
     ClaudeCodeOptions,
@@ -55,6 +58,14 @@ class TestMessageTypes:
         assert msg.subtype == "success"
         assert msg.total_cost_usd == 0.01
         assert msg.session_id == "session-123"
+
+    def test_import_types_module(self):
+        """
+        Smoke test to ensure claude_code_sdk.types imports without errors
+        and defines NotRequired.
+        """
+        module = importlib.reload(importlib.import_module("claude_code_sdk.types"))
+        assert hasattr(module, "NotRequired"), "claude_code_sdk.types should define NotRequired"
 
 
 class TestOptions:


### PR DESCRIPTION
### Body:

This PR addresses an import issue with `typing_extensions` in the SDK.

### Problem:

* The current code unconditionally imports `typing_extensions.NotRequired`
* However, in `pyproject.toml`, `typing_extensions` is only installed for Python `< 3.11`
* On Python 3.11+, `typing.NotRequired` exists, but the package may not be installed
* This causes `ModuleNotFoundError` on a clean install with Python 3.11+

### Solution:

* Use version-conditional imports to fallback to `typing` on Python 3.11+
* Ensures compatibility without forcing unnecessary dependencies


