### PR TITLE
Add settings option to ClaudeCodeOptions

### DIFF
--- a/src/claude_code_sdk/_internal/transport/subprocess_cli.py
+++ b/src/claude_code_sdk/_internal/transport/subprocess_cli.py
@@ -118,6 +118,9 @@ class SubprocessCLITransport(Transport):
         if self._options.resume:
             cmd.extend(["--resume", self._options.resume])
 
+        if self._options.settings:
+            cmd.extend(["--settings", self._options.settings])
+
         if self._options.mcp_servers:
             cmd.extend(
                 ["--mcp-config", json.dumps({"mcpServers": self._options.mcp_servers})]

--- a/src/claude_code_sdk/types.py
+++ b/src/claude_code_sdk/types.py
@@ -127,3 +127,4 @@ class ClaudeCodeOptions:
     model: str | None = None
     permission_prompt_tool_name: str | None = None
     cwd: str | Path | None = None
+    settings: str | None = None


### PR DESCRIPTION
## Summary
- Add `settings` field to `ClaudeCodeOptions` to expose the `--settings` CLI flag
- Allow SDK users to specify custom settings configuration path

## Changes
- Added `settings: str | None = None` field to `ClaudeCodeOptions` dataclass
- Added CLI argument conversion logic in `SubprocessCLITransport` to pass `--settings` flag to Claude Code CLI

## Test plan
- [x] All existing tests pass
- [x] Linting passes (`python -m ruff check`)
- [x] Type checking passes (`python -m mypy src/`)

🤖 Generated with [Claude Code](https://claude.ai/code)