### PR TITLE
remove mcp_tools field from ClaudeCodeOptions

### DIFF
--- a/src/claude_code_sdk/types.py
+++ b/src/claude_code_sdk/types.py
@@ -117,7 +117,6 @@ class ClaudeCodeOptions:
     max_thinking_tokens: int = 8000
     system_prompt: str | None = None
     append_system_prompt: str | None = None
-    mcp_tools: list[str] = field(default_factory=list)
     mcp_servers: dict[str, McpServerConfig] = field(default_factory=dict)
     permission_mode: PermissionMode | None = None
     continue_conversation: bool = False


### PR DESCRIPTION
the `mcp_tools` field in `ClaudeCodeOptions` seems to have been there since the initial commit but I couldn't find any references in the repo, so I believe it may be vestigial and unused