### PR TITLE
Fix a error about KeyError.

### DIFF
--- a/src/claude_code_sdk/_internal/message_parser.py
+++ b/src/claude_code_sdk/_internal/message_parser.py
@@ -109,7 +109,7 @@ def parse_message(data: dict[str, Any]) -> Message:
                             )
 
                 return AssistantMessage(
-                    content=content_blocks, model=data["message"]["model"]
+                    content=content_blocks, model=data["message"].get("model")
                 )
             except KeyError as e:
                 raise MessageParseError(


### PR DESCRIPTION

    Fix KeyError 'model' in message_parser.py
    
    In my macbook, I encountered this issue during try quicky_start.py .
    
    .venv/lib/python3.13/site-packages/claude_code_sdk/_internal/message_parser.py", line 112, in parse_message
             content=content_blocks, model=data["message"]["model"]
                                           ~~~~~~~~~~~~~~~^^^^^^^^^
         KeyError: 'model'
