### PR TITLE
add `end of command options` to sanitize user prompt

### DIFF
--- a/src/claude_code_sdk/_internal/transport/subprocess_cli.py
+++ b/src/claude_code_sdk/_internal/transport/subprocess_cli.py
@@ -157,7 +157,7 @@ class SubprocessCLITransport(Transport):
             cmd.extend(["--input-format", "stream-json"])
         else:
             # String mode: use --print with the prompt
-            cmd.extend(["--print", str(self._prompt)])
+            cmd.extend(["--print", "--", str(self._prompt)])
 
         return cmd
 


### PR DESCRIPTION
The PR should address the issue where user prompt maybe treated as a option with leading `-`
Assuming `claude` does follow POSIX standard, the `--` option should solve the issue.

fixes #129 