### PR TITLE
Add support for custom env vars

### DIFF
--- a/examples/streaming_mode.py
+++ b/examples/streaming_mode.py
@@ -405,7 +405,6 @@ async def main():
         "with_interrupt": example_with_interrupt,
         "manual_message_handling": example_manual_message_handling,
         "with_options": example_with_options,
-        "with_env_vars": example_with_env_vars,
         "async_iterable_prompt": example_async_iterable_prompt,
         "bash_command": example_bash_command,
         "error_handling": example_error_handling,

--- a/examples/streaming_mode.py
+++ b/examples/streaming_mode.py
@@ -188,9 +188,7 @@ async def example_manual_message_handling():
     print("=== Manual Message Handling Example ===")
 
     async with ClaudeSDKClient() as client:
-        await client.query(
-            "List 5 programming languages and their main use cases"
-        )
+        await client.query("List 5 programming languages and their main use cases")
 
         # Manually process messages with custom logic
         languages_found = []
@@ -231,13 +229,14 @@ async def example_with_options():
         allowed_tools=["Read", "Write"],  # Allow file operations
         max_thinking_tokens=10000,
         system_prompt="You are a helpful coding assistant.",
+        env={
+            "ANTHROPIC_MODEL": "claude-3-7-sonnet-20250219",
+        },
     )
 
     async with ClaudeSDKClient(options=options) as client:
         print("User: Create a simple hello.txt file with a greeting message")
-        await client.query(
-            "Create a simple hello.txt file with a greeting message"
-        )
+        await client.query("Create a simple hello.txt file with a greeting message")
 
         tool_uses = []
         async for msg in client.receive_response():
@@ -308,25 +307,27 @@ async def example_async_iterable_prompt():
 async def example_bash_command():
     """Example showing tool use blocks when running bash commands."""
     print("=== Bash Command Example ===")
-    
+
     async with ClaudeSDKClient() as client:
         print("User: Run a bash echo command")
         await client.query("Run a bash echo command that says 'Hello from bash!'")
-        
+
         # Track all message types received
         message_types = []
-        
+
         async for msg in client.receive_messages():
             message_types.append(type(msg).__name__)
-            
+
             if isinstance(msg, UserMessage):
                 # User messages can contain tool results
                 for block in msg.content:
                     if isinstance(block, TextBlock):
                         print(f"User: {block.text}")
                     elif isinstance(block, ToolResultBlock):
-                        print(f"Tool Result (id: {block.tool_use_id}): {block.content[:100] if block.content else 'None'}...")
-                        
+                        print(
+                            f"Tool Result (id: {block.tool_use_id}): {block.content[:100] if block.content else 'None'}..."
+                        )
+
             elif isinstance(msg, AssistantMessage):
                 # Assistant messages can contain tool use blocks
                 for block in msg.content:
@@ -337,15 +338,15 @@ async def example_bash_command():
                         if block.name == "Bash":
                             command = block.input.get("command", "")
                             print(f"  Command: {command}")
-                            
+
             elif isinstance(msg, ResultMessage):
                 print("Result ended")
                 if msg.total_cost_usd:
                     print(f"Cost: ${msg.total_cost_usd:.4f}")
                 break
-        
+
         print(f"\nMessage types received: {', '.join(set(message_types))}")
-    
+
     print("\n")
 
 
@@ -404,6 +405,7 @@ async def main():
         "with_interrupt": example_with_interrupt,
         "manual_message_handling": example_manual_message_handling,
         "with_options": example_with_options,
+        "with_env_vars": example_with_env_vars,
         "async_iterable_prompt": example_async_iterable_prompt,
         "bash_command": example_bash_command,
         "error_handling": example_error_handling,

--- a/hello.txt
+++ b/hello.txt
@@ -1,0 +1,1 @@
+Hello, World!

--- a/hello.txt
+++ b/hello.txt
@@ -1,1 +1,0 @@
-Hello, World!

--- a/src/claude_code_sdk/_internal/transport/subprocess_cli.py
+++ b/src/claude_code_sdk/_internal/transport/subprocess_cli.py
@@ -175,13 +175,20 @@ class SubprocessCLITransport(Transport):
             )
 
             # Enable stdin pipe for both modes (but we'll close it for string mode)
+            # Merge environment variables: system -> user -> SDK required
+            process_env = {
+                **os.environ,  # Start with system environment
+                **self._options.env,  # Override with user-provided env vars
+                "CLAUDE_CODE_ENTRYPOINT": "sdk-py",  # SDK required (last to prevent override)
+            }
+
             self._process = await anyio.open_process(
                 cmd,
                 stdin=PIPE,
                 stdout=PIPE,
                 stderr=self._stderr_file,
                 cwd=self._cwd,
-                env={**os.environ, "CLAUDE_CODE_ENTRYPOINT": "sdk-py"},
+                env=process_env,
             )
 
             if self._process.stdout:

--- a/src/claude_code_sdk/_internal/transport/subprocess_cli.py
+++ b/src/claude_code_sdk/_internal/transport/subprocess_cli.py
@@ -177,9 +177,9 @@ class SubprocessCLITransport(Transport):
             # Enable stdin pipe for both modes (but we'll close it for string mode)
             # Merge environment variables: system -> user -> SDK required
             process_env = {
-                **os.environ,  # Start with system environment
-                **self._options.env,  # Override with user-provided env vars
-                "CLAUDE_CODE_ENTRYPOINT": "sdk-py",  # SDK required (last to prevent override)
+                **os.environ,
+                **self._options.env,  # User-provided env vars
+                "CLAUDE_CODE_ENTRYPOINT": "sdk-py",
             }
 
             self._process = await anyio.open_process(

--- a/src/claude_code_sdk/types.py
+++ b/src/claude_code_sdk/types.py
@@ -137,6 +137,7 @@ class ClaudeCodeOptions:
     cwd: str | Path | None = None
     settings: str | None = None
     add_dirs: list[str | Path] = field(default_factory=list)
+    env: dict[str, str] = field(default_factory=dict)
     extra_args: dict[str, str | None] = field(
         default_factory=dict
     )  # Pass arbitrary CLI flags

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,8 +1,9 @@
 """Tests for Claude SDK transport layer."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
 import os
 import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import anyio
 import pytest
 


### PR DESCRIPTION
## Key changes
- Adds env field to `ClaudeCodeOptions`, allowing custom env vars to cli
- Updates tests and examples

## Motivation
Bringing Python SDK to feature parity with TS SDK, which supports custom env vars

## Notes
- Environment variables are merged in order: system env → user env → SDK required vars
- This implementation seems slightly more robust than the TypeScript version, which can exclude OS envs vars if a user passes a minimal env object
- Some linting changes seem to have been picked up