### PR TITLE
fix: propagate user cwd to subprocess environment

### DIFF
--- a/src/claude_code_sdk/_internal/transport/subprocess_cli.py
+++ b/src/claude_code_sdk/_internal/transport/subprocess_cli.py
@@ -182,6 +182,9 @@ class SubprocessCLITransport(Transport):
                 "CLAUDE_CODE_ENTRYPOINT": "sdk-py",
             }
 
+            if self._cwd:
+                process_env["CWD"] = self._cwd
+
             self._process = await anyio.open_process(
                 cmd,
                 stdin=PIPE,


### PR DESCRIPTION
The subprocess transport was ignoring user-specified cwd from ClaudeCodeOptions, causing the working directory preference to be overridden by os.environ. This fix ensures the CWD environment variable is properly passed to child processes.

- Add CWD env var when self._cwd is set in SubprocessCLITransport
- Fixes issue where custom working directory was not respected
- Maintains backward compatibility

Tests: All existing tests pass