### PR TITLE
Standardize GitHub workflow triggers

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,10 @@
 name: Lint
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
+  push:
+    branches:
+      - 'main'
 
 jobs:
   lint:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -2,7 +2,9 @@ name: Claude Code E2E Test
 
 on:
   pull_request:
-    types: [opened, synchronize]
+  push:
+    branches:
+      - 'main'
 
 jobs:
   integration-test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,10 @@
 name: Test
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
+  push:
+    branches:
+      - 'main'
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Standardized the trigger configuration across test, lint, and e2e workflows
- All workflows now use consistent format with pull_request listed before push
- E2E workflow now also runs on pushes to main branch

## Test plan
- [ ] Verify workflows trigger correctly on pull requests
- [ ] Verify workflows trigger correctly on pushes to main branch
- [ ] Check that e2e tests run successfully on main branch

🤖 Generated with [Claude Code](https://claude.ai/code)