### PR TITLE
Only parse valid JSON objects from stdout stream

### DIFF
--- a/src/claude_code_sdk/_internal/transport/subprocess_cli.py
+++ b/src/claude_code_sdk/_internal/transport/subprocess_cli.py
@@ -318,6 +318,12 @@ class SubprocessCLITransport(Transport):
                     if not json_line:
                         continue
 
+                    # Filter out non-JSON lines when ANTHROPIC_LOG is set
+                    # Only process lines that start with { (valid JSON objects)
+                    if not json_line.startswith('{'):
+                        # Skip non-JSON lines (including ANTHROPIC_LOG output)
+                        continue
+
                     # Keep accumulating partial JSON until we can parse it
                     json_buffer += json_line
 


### PR DESCRIPTION
Motivation:
* When the ANTHROPIC_LOG environment variable is set (e.g., to debug), the Claude CLI outputs extensive logging information directly to stdout, mixed with the JSON messages that the SDK expects to parse. This causes the query() function to return fewer messages than expected, as log lines get concatenated with JSON in the parsing buffer, corrupting the JSON structure.

Approach:
* Modified the JSON parsing logic in SubprocessCLITransport._read_messages_impl() to filter out non-JSON lines before processing. The fix simply skips any line that doesn't start with '{', since all valid SDK messages are JSON objects.