### PR TITLE
Add PostToolUse hook for automatic ruff formatting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(python -m ruff check src/ tests/ --fix)",
+      "Bash(python -m ruff format src/ tests/)",
+      "Bash(python -m mypy src/)",
+      "Bash(python -m pytest tests/)",
+      "Bash(python -m pytest tests/*)"
+    ],
+    "deny": []
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python -m ruff check src/ tests/ --fix && python -m ruff format src/ tests/"
+          }
+        ],
+        "matcher": "Edit|Write|MultiEdit"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Configure automatic formatting via ruff check --fix and ruff format after Edit/Write/MultiEdit operations

🤖 Generated with [Claude Code](https://claude.ai/code)