### PR TITLE
Added base64 image handling to sdk_mcp_server tool calling

### DIFF
--- a/src/claude_code_sdk/__init__.py
+++ b/src/claude_code_sdk/__init__.py
@@ -191,7 +191,7 @@ def create_sdk_mcp_server(
         - ClaudeCodeOptions: Configuration for using servers with query()
     """
     from mcp.server import Server
-    from mcp.types import TextContent, Tool
+    from mcp.types import TextContent, ImageContent, Tool
 
     # Create MCP server instance
     server = Server(name, version=version)
@@ -266,6 +266,15 @@ def create_sdk_mcp_server(
                 for item in result["content"]:
                     if item.get("type") == "text":
                         content.append(TextContent(type="text", text=item["text"]))
+                    if item.get("type") == "image":
+                        source = item["source"]
+                        content.append(
+                            ImageContent(
+                                type="image",
+                                data=source["data"],
+                                mimeType=source["mimeType"],
+                            )
+                        )
 
             # Return just the content list - the decorator wraps it
             return content


### PR DESCRIPTION
With this change claude_code_sdk tools can now also return base64 images, in addition to text, following the MCP standard.

For example:
```
import base64

@tool("mape_response", "prompt", {"foo": str})
def make_response(args):

    fake_bytes = b"someimagebytes"
    encoded_image = base64.b64encode(fake_bytes).decode("utf-8")

    return {
        "content": [
            {"type": "text", "text": "Hello world!"},
            {
                "type": "image",
                "source": {
                    "type": "base64",
                    "mimeType": "image/jpeg",
                    "data": encoded_image,
                },
            },
        ]
    }
```