### PR TITLE
feat: add fork_session option for resuming sessions

### DIFF
--- a/src/claude_code_sdk/_internal/transport/subprocess_cli.py
+++ b/src/claude_code_sdk/_internal/transport/subprocess_cli.py
@@ -153,6 +153,9 @@ class SubprocessCLITransport(Transport):
         if self._options.include_partial_messages:
             cmd.append("--include-partial-messages")
 
+        if self._options.fork_session:
+            cmd.append("--fork-session")
+
         # Add extra args for future CLI flags
         for flag, value in self._options.extra_args.items():
             if value is None:

--- a/src/claude_code_sdk/types.py
+++ b/src/claude_code_sdk/types.py
@@ -314,6 +314,9 @@ class ClaudeCodeOptions:
 
     # Partial message streaming support
     include_partial_messages: bool = False
+    # When true resumed sessions will fork to a new session ID rather than
+    # continuing the previous session.
+    fork_session: bool = False
 
 
 # SDK Control Protocol


### PR DESCRIPTION
Add support for fork_session parameter which allows resumed sessions to fork to a new session ID rather than continuing the previous session.

🤖 Generated with [Claude Code](https://claude.ai/code)