### PR TITLE
refactor: remove unnecessary node installation check

### DIFF
--- a/src/claude_agent_sdk/_internal/transport/subprocess_cli.py
+++ b/src/claude_agent_sdk/_internal/transport/subprocess_cli.py
@@ -66,15 +66,6 @@ class SubprocessCLITransport(Transport):
             if path.exists() and path.is_file():
                 return str(path)
 
-        node_installed = shutil.which("node") is not None
-
-        if not node_installed:
-            error_msg = "Claude Code requires Node.js, which is not installed.\n\n"
-            error_msg += "Install Node.js from: https://nodejs.org/\n"
-            error_msg += "\nAfter installing Node.js, install Claude Code:\n"
-            error_msg += "  npm install -g @anthropic-ai/claude-code"
-            raise CLINotFoundError(error_msg)
-
         raise CLINotFoundError(
             "Claude Code not found. Install with:\n"
             "  npm install -g @anthropic-ai/claude-code\n"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -161,7 +161,7 @@ class TestIntegration:
                 async for _ in query(prompt="test"):
                     pass
 
-            assert "Claude Code requires Node.js" in str(exc_info.value)
+            assert "Claude Code not found" in str(exc_info.value)
 
         anyio.run(_test)
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -25,7 +25,7 @@ class TestSubprocessCLITransport:
         ):
             SubprocessCLITransport(prompt="test", options=ClaudeAgentOptions())
 
-        assert "Claude Code requires Node.js" in str(exc_info.value)
+        assert "Claude Code not found" in str(exc_info.value)
 
     def test_build_command_basic(self):
         """Test building basic CLI command."""


### PR DESCRIPTION
Simplify CLI detection by removing redundant node installation check before throwing CLINotFoundError.

🤖 Generated with [Claude Code](https://claude.ai/code)